### PR TITLE
Remove hide_action calls for rail 5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/*
 .yardoc
 pkg/
 Gemfile.lock
+.idea/*

--- a/lib/resources_controller.rb
+++ b/lib/resources_controller.rb
@@ -456,7 +456,6 @@ module ResourcesController
     
     unless included_modules.include? ResourcesController::InstanceMethods
       class_attribute :specifications, :route_name
-      hide_action :specifications, :route_name
       extend  ResourcesController::ClassMethods
       helper  ResourcesController::Helper
       include ResourcesController::InstanceMethods, ResourcesController::NamedRouteHelper
@@ -557,7 +556,6 @@ private
   
   module InstanceMethods
     def self.included(controller)
-      controller.send :hide_action, *instance_methods
     end
     
     def resource_service=(service)

--- a/lib/resources_controller/named_route_helper.rb
+++ b/lib/resources_controller/named_route_helper.rb
@@ -36,8 +36,6 @@ module ResourcesController
         alias_method_chain :method_missing, :named_route_helper
         alias_method_chain :respond_to?, :named_route_helper
       end
-      base.hide_action *instance_methods
-      base.hide_action :method_missing_without_named_route_helper, :respond_to_without_named_route_helper?, :respond_to?
     end
 
     def method_missing_with_named_route_helper(method, *args, &block)


### PR DESCRIPTION
hide_action actually does nothing now that actions are not automatically
exposed to the router.